### PR TITLE
Update CMake configuration for compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_TOOLCHAIN_FILE=../../ndk/android-ndk-r25c/build/cmake/android.toolchain.cmake \
                 -DANDROID_ABI=arm64-v8a \
-                -DANDROID_PLATFORM=android-21 \
+                -DANDROID_PLATFORM=android-23 \
                 ../
           make -j$(nproc)
           make install DESTDIR=../release-android

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -66,7 +66,7 @@ jobs:
             cmake -DCMAKE_BUILD_TYPE=Release \
                   -DCMAKE_TOOLCHAIN_FILE=../../ndk/android-ndk-r25c/build/cmake/android.toolchain.cmake \
                   -DANDROID_ABI=$arch \
-                  -DANDROID_PLATFORM=android-21 \
+                  -DANDROID_PLATFORM=android-23 \
                   ../
             make -j$(nproc)
             cd ..

--- a/ACE/CMakeLists.txt
+++ b/ACE/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Set the minimum version of CMake that can be used To find the cmake version
 # run $ cmake --version
 #  	error when compiling tests
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 # =======================================
 # require compiler that supports c++20
 # https://stackoverflow.com/questions/42834844/how-to-get-cmake-to-pass-either-std-c14-c1y-or-c17-c1z-based-on-gcc-vers

--- a/ANDROID_BUILD_FIXES.md
+++ b/ANDROID_BUILD_FIXES.md
@@ -1,0 +1,49 @@
+# Android Build Fixes
+
+## Issues Fixed
+
+### 1. ANDROID_PLATFORM Version Mismatch
+
+**Problem**: The GitHub Actions workflows were setting `ANDROID_PLATFORM=android-21`, but the CMakeLists.txt requires at least API level 23 for `process_vm_readv` and `process_vm_writev` functions.
+
+**Error Message**:
+```
+CMake Error at CMakeLists.txt:56 (message):
+  You need to set -DANDROID_PLATFORM to at least "android-23"
+```
+
+**Fix**: Updated both workflow files to use `android-23`:
+- `.github/workflows/weekly-build.yml`: Changed `-DANDROID_PLATFORM=android-21` to `-DANDROID_PLATFORM=android-23`
+- `.github/workflows/release.yml`: Changed `-DANDROID_PLATFORM=android-21` to `-DANDROID_PLATFORM=android-23`
+
+### 2. CMake Deprecation Warnings
+
+**Problem**: CMake was showing deprecation warnings about compatibility with CMake < 3.10.
+
+**Error Message**:
+```
+CMake Deprecation Warning at android.toolchain.cmake:34 (cmake_minimum_required):
+  Compatibility with CMake < 3.10 will be removed from a future version of CMake.
+  Update the VERSION argument <min> value.
+```
+
+**Fix**: Updated `ACE/CMakeLists.txt` to require CMake 3.15 instead of 3.12:
+```cmake
+cmake_minimum_required(VERSION 3.15)
+```
+
+## Why These Fixes Are Necessary
+
+1. **API Level 23 Requirement**: The ACE project uses `process_vm_readv` and `process_vm_writev` functions which are only available starting from Android API level 23. These functions are essential for memory reading/writing operations on Android.
+
+2. **CMake Version Compatibility**: Using a higher CMake version eliminates deprecation warnings from the Android NDK toolchain files and ensures better compatibility with newer build systems.
+
+## Files Modified
+
+- `.github/workflows/weekly-build.yml`
+- `.github/workflows/release.yml`
+- `ACE/CMakeLists.txt`
+
+## Testing
+
+After these fixes, the Android build should complete successfully without the platform version error or CMake deprecation warnings.


### PR DESCRIPTION
Update Android platform level to 23 and CMake minimum version to 3.15 to resolve build errors and deprecation warnings.

The project requires Android API level 23 for `process_vm_readv` and `process_vm_writev` functions, which were causing build failures when `android-21` was used. Increasing the CMake minimum version addresses deprecation warnings from the NDK toolchain.