### PR TITLE
Fix security issues in signing process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,25 +186,64 @@ jobs:
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         working-directory: ./ATG
         run: |
-          # Install build tools if not present
-          if ! command -v zipalign &> /dev/null; then
-            sudo apt-get install -y android-sdk-build-tools
-          fi
-          
           # Find the APK file
           APK_PATH=$(find ./app/build/outputs/apk/debug -name "*.apk" | head -1)
           if [ -n "$APK_PATH" ]; then
+            echo "Found APK: $APK_PATH"
+            
+            # Create a copy of the unsigned APK
+            cp "$APK_PATH" "${APK_PATH}.unsigned"
+            
+            # Remove existing signatures from APK if present
+            echo "Removing existing signatures if any..."
+            zip -d "$APK_PATH" "META-INF/*.SF" "META-INF/*.RSA" "META-INF/*.DSA" "META-INF/MANIFEST.MF" 2>/dev/null || true
+            
             # Sign the APK using jarsigner with SHA256
+            echo "Signing APK..."
             jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA256 \
               -keystore ./app/keystore.jks \
               -storepass "${{ secrets.APP_KEYSTORE_PASSWORD }}" \
               -keypass "${{ secrets.APP_KEY_PASSWORD }}" \
+              -tsa http://timestamp.digicert.com \
               "$APK_PATH" "${{ secrets.APP_KEYSTORE_ALIAS }}"
             
             # Verify the signature
+            echo "Verifying signature..."
             jarsigner -verify -verbose -certs "$APK_PATH"
             
-            echo "APK signed successfully: $APK_PATH"
+            # Install Android SDK build-tools if needed
+            if ! command -v zipalign &> /dev/null; then
+              ANDROID_SDK_ROOT="/usr/local/lib/android/sdk"
+              BUILD_TOOLS_VERSION="34.0.0"
+              ZIPALIGN="${ANDROID_SDK_ROOT}/build-tools/${BUILD_TOOLS_VERSION}/zipalign"
+              
+              if [ ! -f "$ZIPALIGN" ]; then
+                echo "Installing Android SDK build-tools..."
+                sdkmanager --install "build-tools;${BUILD_TOOLS_VERSION}" || {
+                  # Fallback to apt package
+                  sudo apt-get install -y zipalign
+                  ZIPALIGN="zipalign"
+                }
+              fi
+            else
+              ZIPALIGN="zipalign"
+            fi
+            
+            # Zipalign the APK
+            if command -v $ZIPALIGN &> /dev/null || [ -f "$ZIPALIGN" ]; then
+              echo "Zipaligning APK..."
+              mv "$APK_PATH" "${APK_PATH}.unaligned"
+              $ZIPALIGN -v 4 "${APK_PATH}.unaligned" "$APK_PATH"
+              rm -f "${APK_PATH}.unaligned"
+              echo "APK zipaligned successfully"
+            else
+              echo "Warning: zipalign not found, skipping zipalign step"
+            fi
+            
+            # Clean up backup
+            rm -f "${APK_PATH}.unsigned"
+            
+            echo "APK signed and processed successfully: $APK_PATH"
           else
             echo "No APK file found to sign"
           fi
@@ -262,25 +301,64 @@ jobs:
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         working-directory: ./billing-hack
         run: |
-          # Install build tools if not present
-          if ! command -v zipalign &> /dev/null; then
-            sudo apt-get install -y android-sdk-build-tools
-          fi
-          
           # Find the APK file
           APK_PATH=$(find ./app/build/outputs/apk/debug -name "*.apk" | head -1)
           if [ -n "$APK_PATH" ]; then
+            echo "Found APK: $APK_PATH"
+            
+            # Create a copy of the unsigned APK
+            cp "$APK_PATH" "${APK_PATH}.unsigned"
+            
+            # Remove existing signatures from APK if present
+            echo "Removing existing signatures if any..."
+            zip -d "$APK_PATH" "META-INF/*.SF" "META-INF/*.RSA" "META-INF/*.DSA" "META-INF/MANIFEST.MF" 2>/dev/null || true
+            
             # Sign the APK using jarsigner with SHA256
+            echo "Signing APK..."
             jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA256 \
               -keystore ./app/keystore.jks \
               -storepass "${{ secrets.APP_KEYSTORE_PASSWORD }}" \
               -keypass "${{ secrets.APP_KEY_PASSWORD }}" \
+              -tsa http://timestamp.digicert.com \
               "$APK_PATH" "${{ secrets.APP_KEYSTORE_ALIAS }}"
             
             # Verify the signature
+            echo "Verifying signature..."
             jarsigner -verify -verbose -certs "$APK_PATH"
             
-            echo "APK signed successfully: $APK_PATH"
+            # Install Android SDK build-tools if needed
+            if ! command -v zipalign &> /dev/null; then
+              ANDROID_SDK_ROOT="/usr/local/lib/android/sdk"
+              BUILD_TOOLS_VERSION="34.0.0"
+              ZIPALIGN="${ANDROID_SDK_ROOT}/build-tools/${BUILD_TOOLS_VERSION}/zipalign"
+              
+              if [ ! -f "$ZIPALIGN" ]; then
+                echo "Installing Android SDK build-tools..."
+                sdkmanager --install "build-tools;${BUILD_TOOLS_VERSION}" || {
+                  # Fallback to apt package
+                  sudo apt-get install -y zipalign
+                  ZIPALIGN="zipalign"
+                }
+              fi
+            else
+              ZIPALIGN="zipalign"
+            fi
+            
+            # Zipalign the APK
+            if command -v $ZIPALIGN &> /dev/null || [ -f "$ZIPALIGN" ]; then
+              echo "Zipaligning APK..."
+              mv "$APK_PATH" "${APK_PATH}.unaligned"
+              $ZIPALIGN -v 4 "${APK_PATH}.unaligned" "$APK_PATH"
+              rm -f "${APK_PATH}.unaligned"
+              echo "APK zipaligned successfully"
+            else
+              echo "Warning: zipalign not found, skipping zipalign step"
+            fi
+            
+            # Clean up backup
+            rm -f "${APK_PATH}.unsigned"
+            
+            echo "APK signed and processed successfully: $APK_PATH"
           else
             echo "No APK file found to sign"
           fi
@@ -354,22 +432,64 @@ jobs:
           
       - name: Sign Release APK files
         run: |
+          # Install Android SDK build-tools if needed
+          if ! command -v zipalign &> /dev/null; then
+            ANDROID_SDK_ROOT="/usr/local/lib/android/sdk"
+            BUILD_TOOLS_VERSION="34.0.0"
+            ZIPALIGN="${ANDROID_SDK_ROOT}/build-tools/${BUILD_TOOLS_VERSION}/zipalign"
+            
+            if [ ! -f "$ZIPALIGN" ]; then
+              echo "Installing Android SDK build-tools..."
+              sdkmanager --install "build-tools;${BUILD_TOOLS_VERSION}" || {
+                # Fallback to apt package
+                sudo apt-get install -y zipalign
+                ZIPALIGN="zipalign"
+              }
+            fi
+          else
+            ZIPALIGN="zipalign"
+          fi
+          
           # Find and sign all APK files in the release directory
           find ./release -name "*.apk" | while read APK_PATH; do
             if [ -f "$APK_PATH" ]; then
-              echo "Signing APK: $APK_PATH"
+              echo "Processing APK: $APK_PATH"
+              
+              # Create a copy of the unsigned APK
+              cp "$APK_PATH" "${APK_PATH}.unsigned"
+              
+              # Remove existing signatures from APK if present
+              echo "Removing existing signatures if any..."
+              zip -d "$APK_PATH" "META-INF/*.SF" "META-INF/*.RSA" "META-INF/*.DSA" "META-INF/MANIFEST.MF" 2>/dev/null || true
               
               # Sign the APK using jarsigner with SHA256
+              echo "Signing APK..."
               jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA256 \
                 -keystore ./release/keystore.jks \
                 -storepass "${{ secrets.APP_KEYSTORE_PASSWORD }}" \
                 -keypass "${{ secrets.APP_KEY_PASSWORD }}" \
+                -tsa http://timestamp.digicert.com \
                 "$APK_PATH" "${{ secrets.APP_KEYSTORE_ALIAS }}"
               
               # Verify the signature
+              echo "Verifying signature..."
               jarsigner -verify -verbose -certs "$APK_PATH"
               
-              echo "APK signed successfully: $APK_PATH"
+              # Zipalign the APK
+              if command -v $ZIPALIGN &> /dev/null || [ -f "$ZIPALIGN" ]; then
+                echo "Zipaligning APK..."
+                mv "$APK_PATH" "${APK_PATH}.unaligned"
+                $ZIPALIGN -v 4 "${APK_PATH}.unaligned" "$APK_PATH"
+                rm -f "${APK_PATH}.unaligned"
+                echo "APK zipaligned successfully"
+              else
+                echo "Warning: zipalign not found, skipping zipalign step"
+              fi
+              
+              # Clean up backup
+              rm -f "${APK_PATH}.unsigned"
+              
+              echo "APK signed and processed successfully: $APK_PATH"
             fi
           done
           

--- a/APK_SIGNING_SETUP.md
+++ b/APK_SIGNING_SETUP.md
@@ -2,9 +2,9 @@
 
 ## Создание keystore с помощью keytool
 
-1. Создайте keystore файл:
+1. Создайте keystore файл с современными алгоритмами:
 ```bash
-keytool -genkey -v -keystore app-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias app-key
+keytool -genkey -v -keystore app-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias app-key -sigalg SHA256withRSA -storetype PKCS12
 ```
 
 2. Следуйте инструкциям для заполнения информации:
@@ -65,3 +65,24 @@ keytool -list -v -keystore app-release-key.jks
 - Используйте сильные пароли для keystore и ключей
 - Сохраните резервную копию keystore файла
 - Не добавляйте keystore файл в git repository
+
+## Решение распространенных проблем
+
+### Ошибка "SHA1 algorithm is considered a security risk"
+Эта ошибка возникает при использовании устаревших алгоритмов. Решение:
+- Используйте `-sigalg SHA256withRSA -digestalg SHA256` при подписи
+- Создавайте keystore с `-sigalg SHA256withRSA`
+
+### Ошибка "invalid SHA-256 signature file digest"
+Эта ошибка возникает, когда APK уже подписан. Решение:
+1. Удалите существующие подписи перед повторной подписью:
+```bash
+zip -d app.apk "META-INF/*.SF" "META-INF/*.RSA" "META-INF/*.DSA" "META-INF/MANIFEST.MF"
+```
+2. Затем подпишите APK заново
+
+### Рекомендации по zipalign
+После подписи APK рекомендуется выполнить zipalign:
+```bash
+zipalign -v 4 app-signed.apk app-final.apk
+```

--- a/TERMUX_KEYTOOL_GUIDE.md
+++ b/TERMUX_KEYTOOL_GUIDE.md
@@ -18,7 +18,7 @@ keytool -help
 
 ### Базовая команда
 ```bash
-keytool -genkey -v -keystore app-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias app-key
+keytool -genkey -v -keystore app-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias app-key -sigalg SHA256withRSA
 ```
 
 ### Подробная команда с параметрами
@@ -31,7 +31,8 @@ keytool -genkeypair \
   -validity 10000 \
   -alias app-key \
   -storetype JKS \
-  -dname "CN=YourName, OU=YourOrgUnit, O=YourOrg, L=YourCity, ST=YourState, C=YourCountry"
+  -dname "CN=YourName, OU=YourOrgUnit, O=YourOrg, L=YourCity, ST=YourState, C=YourCountry" \
+  -sigalg SHA256withRSA
 ```
 
 ## Интерактивная генерация
@@ -78,7 +79,8 @@ keytool -genkeypair \
   -keysize 2048 \
   -validity 10000 \
   -alias my-app \
-  -dname "CN=Developer, OU=Mobile, O=MyCompany, L=Moscow, ST=Moscow, C=RU"
+  -dname "CN=Developer, OU=Mobile, O=MyCompany, L=Moscow, ST=Moscow, C=RU" \
+  -sigalg SHA256withRSA
 ```
 
 ### Для корпоративного использования
@@ -90,7 +92,8 @@ keytool -genkeypair \
   -keysize 4096 \
   -validity 25000 \
   -alias company-app \
-  -dname "CN=Company Developer, OU=Mobile Development, O=Company Ltd, L=City, ST=Region, C=RU"
+  -dname "CN=Company Developer, OU=Mobile Development, O=Company Ltd, L=City, ST=Region, C=RU" \
+  -sigalg SHA256withRSA
 ```
 
 ## Параметры команды
@@ -104,6 +107,7 @@ keytool -genkeypair \
 - `-alias` - псевдоним для ключа
 - `-storetype JKS` - тип keystore (JKS по умолчанию)
 - `-dname` - Distinguished Name для сертификата
+- `-sigalg SHA256withRSA` - алгоритм подписи (рекомендуется для безопасности)
 
 ## Проверка созданного keystore
 
@@ -158,12 +162,14 @@ keytool -import -alias trusted-cert -file certificate.crt -keystore app-release-
 3. **Безопасность**: Не передавайте keystore по незащищенным каналам
 4. **Срок действия**: Устанавливайте долгий срок действия (25+ лет)
 5. **Размер ключа**: Используйте 2048 или 4096 бит для безопасности
+6. **Алгоритмы**: Всегда используйте SHA256withRSA вместо SHA1 для безопасности
+7. **Тип хранилища**: Рекомендуется использовать PKCS12 вместо JKS
 
 ## Пример полного процесса
 
 ```bash
 # 1. Генерация keystore
-keytool -genkeypair -v -keystore my-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias my-app-key
+keytool -genkeypair -v -keystore my-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias my-app-key -sigalg SHA256withRSA
 
 # 2. Проверка
 keytool -list -v -keystore my-release-key.jks

--- a/sign_apk.sh
+++ b/sign_apk.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Script to sign APK files with proper handling of existing signatures
+# Usage: ./sign_apk.sh <apk_file> <keystore_file> <keystore_password> <key_password> <alias>
+
+set -e
+
+# Check arguments
+if [ $# -lt 5 ]; then
+    echo "Usage: $0 <apk_file> <keystore_file> <keystore_password> <key_password> <alias>"
+    exit 1
+fi
+
+APK_FILE="$1"
+KEYSTORE_FILE="$2"
+KEYSTORE_PASSWORD="$3"
+KEY_PASSWORD="$4"
+ALIAS="$5"
+
+# Check if APK file exists
+if [ ! -f "$APK_FILE" ]; then
+    echo "Error: APK file not found: $APK_FILE"
+    exit 1
+fi
+
+# Check if keystore file exists
+if [ ! -f "$KEYSTORE_FILE" ]; then
+    echo "Error: Keystore file not found: $KEYSTORE_FILE"
+    exit 1
+fi
+
+echo "Processing APK: $APK_FILE"
+
+# Create backup
+cp "$APK_FILE" "${APK_FILE}.backup"
+
+# Remove existing signatures if present
+echo "Removing existing signatures if any..."
+zip -d "$APK_FILE" "META-INF/*.SF" "META-INF/*.RSA" "META-INF/*.DSA" "META-INF/MANIFEST.MF" 2>/dev/null || true
+
+# Sign the APK
+echo "Signing APK..."
+jarsigner -verbose \
+    -sigalg SHA256withRSA \
+    -digestalg SHA256 \
+    -keystore "$KEYSTORE_FILE" \
+    -storepass "$KEYSTORE_PASSWORD" \
+    -keypass "$KEY_PASSWORD" \
+    -tsa http://timestamp.digicert.com \
+    "$APK_FILE" "$ALIAS"
+
+# Verify the signature
+echo "Verifying signature..."
+jarsigner -verify -verbose -certs "$APK_FILE"
+
+# Check if zipalign is available
+if command -v zipalign &> /dev/null; then
+    echo "Zipaligning APK..."
+    mv "$APK_FILE" "${APK_FILE}.unaligned"
+    zipalign -v 4 "${APK_FILE}.unaligned" "$APK_FILE"
+    rm -f "${APK_FILE}.unaligned"
+    echo "APK zipaligned successfully"
+else
+    echo "Warning: zipalign not found. Install Android SDK build-tools to enable zipalign."
+    echo "You can install it with: sudo apt-get install zipalign"
+fi
+
+echo "APK signed successfully: $APK_FILE"
+echo "Backup saved as: ${APK_FILE}.backup"


### PR DESCRIPTION
Update Android APK signing process in CI/CD and documentation.

Resolve `jarsigner` errors related to SHA1 and invalid signatures by using modern algorithms, removing old signatures, and adding the `zipalign` step for proper APK optimization.