### PR TITLE
Fix apk signature compatibility issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,8 +178,12 @@ jobs:
           if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
             echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ./ATG/app/release.keystore
             echo "Using keystore from secrets"
+            echo "Keystore info:"
+            keytool -list -v -keystore ./ATG/app/release.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD || 'android' }} || echo "Failed to read keystore"
           else
             echo "No keystore secret found, using local keystore"
+            echo "Local keystore info:"
+            keytool -list -v -keystore ./ATG/app/release.keystore -storepass android || echo "Failed to read local keystore"
           fi
 
       - name: build release
@@ -189,7 +193,13 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS || 'androiddebugkey' }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD || 'android' }}
-        run: ./gradlew assembleRelease
+        run: |
+          echo "Building with signing config:"
+          echo "KEYSTORE_FILE: $KEYSTORE_FILE"
+          echo "KEY_ALIAS: $KEY_ALIAS"
+          echo "Using keystore password: $(echo $KEYSTORE_PASSWORD | sed 's/./*/g')"
+          echo "Using key password: $(echo $KEY_PASSWORD | sed 's/./*/g')"
+          ./gradlew assembleRelease
 
       - name: build debug (for regular builds)
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
@@ -240,8 +250,12 @@ jobs:
           if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
             echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ./billing-hack/app/release.keystore
             echo "Using keystore from secrets"
+            echo "Keystore info:"
+            keytool -list -v -keystore ./billing-hack/app/release.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD || 'android' }} || echo "Failed to read keystore"
           else
             echo "No keystore secret found, using local keystore"
+            echo "Local keystore info:"
+            keytool -list -v -keystore ./billing-hack/app/release.keystore -storepass android || echo "Failed to read local keystore"
           fi
 
       - name: build release
@@ -251,7 +265,13 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS || 'androiddebugkey' }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD || 'android' }}
-        run: ./gradlew assembleRelease
+        run: |
+          echo "Building with signing config:"
+          echo "KEYSTORE_FILE: $KEYSTORE_FILE"
+          echo "KEY_ALIAS: $KEY_ALIAS"
+          echo "Using keystore password: $(echo $KEYSTORE_PASSWORD | sed 's/./*/g')"
+          echo "Using key password: $(echo $KEY_PASSWORD | sed 's/./*/g')"
+          ./gradlew assembleRelease
 
       - name: build debug (for regular builds)
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'

--- a/APK_SIGNING_GUIDE.md
+++ b/APK_SIGNING_GUIDE.md
@@ -1,0 +1,61 @@
+# Руководство по настройке подписи APK в GitHub Actions
+
+## Проблема с подписью APK
+
+Если при установке APK на Android появляется ошибка о несовместимости подписи, это означает, что подпись APK не совпадает с уже установленной версией приложения.
+
+## Настройка GitHub Secrets
+
+Для правильной работы подписи APK в GitHub Actions нужно настроить следующие secrets:
+
+### 1. KEYSTORE_BASE64
+- Кодированный в base64 файл keystore
+- Создание: `base64 -w 0 your-keystore.jks`
+- Добавить в Settings > Secrets and variables > Actions
+
+### 2. KEYSTORE_PASSWORD
+- Пароль от keystore файла
+- По умолчанию: `android`
+
+### 3. KEY_ALIAS
+- Алиас ключа в keystore
+- По умолчанию: `androiddebugkey`
+
+### 4. KEY_PASSWORD
+- Пароль от ключа
+- По умолчанию: `android`
+
+## Проверка существующих keystore файлов
+
+Для проверки алиасов в существующих keystore файлах:
+
+```bash
+# Для ATG проекта
+keytool -list -v -keystore ATG/app/release.keystore -storepass android
+
+# Для billing-hack проекта
+keytool -list -v -keystore billing-hack/app/release.keystore -storepass android
+```
+
+## Исправления в коде
+
+Внесены следующие изменения:
+
+1. **build.gradle файлы**: Настроены для использования правильного алиаса `androiddebugkey`
+2. **main.yml workflow**: Добавлена отладочная информация для диагностики проблем
+3. **Согласованность**: Все настройки теперь используют одинаковые значения
+
+## Рекомендации
+
+1. **Для production**: Создайте собственный keystore с уникальными паролями
+2. **Для testing**: Используйте существующие debug keystore файлы
+3. **Безопасность**: Никогда не коммитьте production keystore файлы в репозиторий
+
+## Отладка
+
+Workflow теперь выводит отладочную информацию:
+- Информация о keystore файле
+- Параметры подписи (пароли скрыты)
+- Используемые алиасы
+
+Эта информация поможет диагностировать проблемы с подписью APK.

--- a/ATG/app/build.gradle
+++ b/ATG/app/build.gradle
@@ -52,14 +52,14 @@ android {
                 // Fallback to local release keystore
                 storeFile file('release.keystore')
                 storePassword 'android'
-                keyAlias 'mykey'
+                keyAlias 'androiddebugkey'
                 keyPassword 'android'
             }
         }
         debug {
             storeFile file('release.keystore')
             storePassword 'android'
-            keyAlias 'mykey'
+            keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
     }

--- a/ATG/app/build.gradle
+++ b/ATG/app/build.gradle
@@ -49,12 +49,18 @@ android {
                 keyAlias KEY_ALIAS
                 keyPassword KEY_PASSWORD
             } else {
-                // Fallback to local keystore for local development
+                // Fallback to local release keystore
                 storeFile file('release.keystore')
                 storePassword 'android'
-                keyAlias 'androiddebugkey'
+                keyAlias 'mykey'
                 keyPassword 'android'
             }
+        }
+        debug {
+            storeFile file('release.keystore')
+            storePassword 'android'
+            keyAlias 'mykey'
+            keyPassword 'android'
         }
     }
 
@@ -63,6 +69,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+        }
+        debug {
+            signingConfig signingConfigs.debug
         }
     }
 

--- a/billing-hack/app/build.gradle
+++ b/billing-hack/app/build.gradle
@@ -26,14 +26,14 @@ android {
                 // Fallback to local release keystore
                 storeFile file('release.keystore')
                 storePassword 'android'
-                keyAlias 'mykey'
+                keyAlias 'androiddebugkey'
                 keyPassword 'android'
             }
         }
         debug {
             storeFile file('release.keystore')
             storePassword 'android'
-            keyAlias 'mykey'
+            keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
     }

--- a/billing-hack/app/build.gradle
+++ b/billing-hack/app/build.gradle
@@ -23,12 +23,18 @@ android {
                 keyAlias KEY_ALIAS
                 keyPassword KEY_PASSWORD
             } else {
-                // Fallback to local keystore for local development
+                // Fallback to local release keystore
                 storeFile file('release.keystore')
                 storePassword 'android'
-                keyAlias 'androiddebugkey'
+                keyAlias 'mykey'
                 keyPassword 'android'
             }
+        }
+        debug {
+            storeFile file('release.keystore')
+            storePassword 'android'
+            keyAlias 'mykey'
+            keyPassword 'android'
         }
     }
 
@@ -37,6 +43,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+        }
+        debug {
+            signingConfig signingConfigs.debug
         }
     }
 


### PR DESCRIPTION
Standardize APK signing configuration and enhance GitHub Actions workflow to resolve Android installation signature incompatibility.

The problem stemmed from inconsistent `keyAlias` values between `build.gradle` files, existing keystore files, and the GitHub Actions workflow. This PR aligns all configurations to use `androiddebugkey`, adds explicit debug signing configurations for consistency, and improves the GitHub Actions workflow with additional debugging output for signing steps. A new guide (`APK_SIGNING_GUIDE.md`) is also added for future reference on setting up secrets and troubleshooting.